### PR TITLE
allow restriction to multiple hosted domains and registration as globally disabled action

### DIFF
--- a/_test/checkMail.test.php
+++ b/_test/checkMail.test.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * General tests for the oauth plugin
+ *
+ * @group plugin_oauth
+ * @group plugins
+ */
+class checkMail_plugin_oauth_test extends DokuWikiTest {
+
+    protected $pluginsEnabled = array('oauth');
+
+    public function test_checkMail_twoDomains() {
+
+        global $conf;
+        $conf['plugin']['oauth']['mailRestriction'] = '@foo.org,@example.com';
+
+        /** @var helper_plugin_oauth $hlp */
+        $hlp     = plugin_load('helper', 'oauth');
+
+        $testmail = "bar@foo.org";
+        $this->assertTrue($hlp->checkMail($testmail),$testmail);
+        $testmail = "bar@example.com";
+        $this->assertTrue($hlp->checkMail($testmail), $testmail);
+        $testmail = "bar@bar.org";
+        $this->assertFalse($hlp->checkMail($testmail), $testmail);
+    }
+
+    public function test_checkMail_oneDomains() {
+
+        global $conf;
+        $conf['plugin']['oauth']['mailRestriction'] = '@foo.org';
+
+        /** @var helper_plugin_oauth $hlp */
+        $hlp     = plugin_load('helper', 'oauth');
+
+        $testmail = "bar@foo.org";
+        $this->assertTrue($hlp->checkMail($testmail),$testmail);
+        $testmail = "bar@example.com";
+        $this->assertFalse($hlp->checkMail($testmail), $testmail);
+        $testmail = "bar@bar.org";
+        $this->assertFalse($hlp->checkMail($testmail), $testmail);
+    }
+
+}

--- a/action.php
+++ b/action.php
@@ -205,8 +205,7 @@ class action_plugin_oauth extends DokuWiki_Action_Plugin {
         $validDomains = $hlp->getValidDomains();
 
         if ($validDomains[0] !== '') {
-            $domainListing = $hlp->getValidDomains(true);
-            $html .= sprintf($this->getLang('eMailRestricted'), $domainListing);
+            $html .= sprintf($this->getLang('eMailRestricted'), join(', ', $validDomains));
         }
 
         if ($singleService == '') {

--- a/action.php
+++ b/action.php
@@ -46,12 +46,16 @@ class action_plugin_oauth extends DokuWiki_Action_Plugin {
         if (isset($_SESSION[DOKU_COOKIE]['oauth-done']['do']) || !empty($_SESSION[DOKU_COOKIE]['oauth-done']['rev'])){
             global $ACT, $TEXT, $PRE, $SUF, $SUM;
             $ACT = $_SESSION[DOKU_COOKIE]['oauth-done']['do'];
-            if (isset($_SESSION[DOKU_COOKIE]['oauth-done']['wikitext'])) {
+            if (!empty($_SESSION[DOKU_COOKIE]['oauth-done']['wikitext'])) {
                 $TEXT = cleanText($_SESSION[DOKU_COOKIE]['oauth-done']['wikitext']);
                 $PRE = cleanText(substr($_SESSION[DOKU_COOKIE]['oauth-done']['prefix'], 0, -1));
                 $SUF = cleanText($_SESSION[DOKU_COOKIE]['oauth-done']['suffix']);
                 $SUM = $_SESSION[DOKU_COOKIE]['oauth-done']['summary'];
                 $INPUT->post->set('sectok', $_SESSION[DOKU_COOKIE]['oauth-done']['sectok']);
+            }
+            if ($ACT === 'save' && empty($TEXT))
+            {
+                $ACT = 'show';
             }
 
             // resetting INPUT, ->post and ->get

--- a/action.php
+++ b/action.php
@@ -202,8 +202,11 @@ class action_plugin_oauth extends DokuWiki_Action_Plugin {
         $form =& $event->data;
         $html = '';
 
-        if ($this->getConf('mailRestriction') !== '') {
-            $html .= sprintf($this->getLang('eMailRestricted'),$this->getConf('mailRestriction'));
+        $validDomains = $hlp->getValidDomains();
+
+        if ($validDomains[0] !== '') {
+            $domainListing = $hlp->getValidDomains(true);
+            $html .= sprintf($this->getLang('eMailRestricted'), $domainListing);
         }
 
         if ($singleService == '') {

--- a/action.php
+++ b/action.php
@@ -204,7 +204,7 @@ class action_plugin_oauth extends DokuWiki_Action_Plugin {
 
         $validDomains = $hlp->getValidDomains();
 
-        if ($validDomains[0] !== '') {
+        if (count($validDomains) > 0) {
             $html .= sprintf($this->getLang('eMailRestricted'), join(', ', $validDomains));
         }
 

--- a/auth.php
+++ b/auth.php
@@ -92,7 +92,7 @@ class auth_plugin_oauth extends auth_plugin_authplain {
                     $uinfo['user'] = $user;
                     $uinfo['name'] = $sinfo['name'];
                     $uinfo['grps'] = array_merge((array) $uinfo['grps'], $sinfo['grps']);
-                } else {
+                } elseif (strpos($conf['disableactions'],'register') === False) {
                     // new user, create him - making sure the login is unique by adding a number if needed
                     $user  = $uinfo['user'];
                     $count = '';
@@ -120,6 +120,9 @@ class auth_plugin_oauth extends auth_plugin_authplain {
                     // send notification about the new user
                     $subscription = new Subscription();
                     $subscription->send_register($user, $uinfo['name'], $uinfo['mail']);
+                } else {
+                    msg('Self-Registration is currently disabled. Please ask your DokuWiki administrator to create your account manually.', -1);
+                    return false;
                 }
 
                 // set user session

--- a/auth.php
+++ b/auth.php
@@ -92,7 +92,7 @@ class auth_plugin_oauth extends auth_plugin_authplain {
                     $uinfo['user'] = $user;
                     $uinfo['name'] = $sinfo['name'];
                     $uinfo['grps'] = array_merge((array) $uinfo['grps'], $sinfo['grps']);
-                } elseif (strpos($conf['disableactions'],'register') === False) {
+                } elseif (actionOK('register')) {
                     // new user, create him - making sure the login is unique by adding a number if needed
                     $user  = $uinfo['user'];
                     $count = '';

--- a/classes/AbstractAdapter.php
+++ b/classes/AbstractAdapter.php
@@ -132,7 +132,7 @@ abstract class AbstractAdapter {
         if ($validDomains[0] !== '') {
             $userData = $this->getUser();
             if (!$this->hlp->checkMail($userData['mail'])) {
-                msg(sprintf($this->hlp->getLang("rejectedEMail"),$this->hlp->getValidDomains(true)),-1);
+                msg(sprintf($this->hlp->getLang("rejectedEMail"),join(', ', $validDomains)),-1);
                 send_redirect(wl('', array('do' => 'login',),false,'&'));
             }
         }

--- a/classes/AbstractAdapter.php
+++ b/classes/AbstractAdapter.php
@@ -127,24 +127,19 @@ abstract class AbstractAdapter {
                 return false;
             }
         }
-        if ($this->hlp->getConf("mailRestriction") !== '') {
-            return $this->checkMail();
+
+        $validDomains = $this->hlp->getValidDomains();
+        if ($validDomains[0] !== '') {
+            $userData = $this->getUser();
+            if (!$this->hlp->checkMail($userData['mail'])) {
+                msg(sprintf($this->hlp->getLang("rejectedEMail"),$this->hlp->getValidDomains(true)),-1);
+                send_redirect(wl('', array('do' => 'login',),false,'&'));
+            }
         }
         return true;
     }
 
-    /**
-     * @return bool
-     */
-    public function checkMail() {
-        $hostedDomain = $this->hlp->getConf("mailRestriction");
-        $userData = $this->getUser();
-        if (substr($userData['mail'], -strlen($hostedDomain)) === $hostedDomain) {
-            return true;
-        }
-        msg(sprintf($this->hlp->getLang("rejectedEMail"),$hostedDomain),-1);
-        send_redirect(wl('', array('do' => 'login',),false,'&'));
-    }
+
 
     /**
      * Return the name of the oAuth service class to use

--- a/classes/AbstractAdapter.php
+++ b/classes/AbstractAdapter.php
@@ -129,7 +129,7 @@ abstract class AbstractAdapter {
         }
 
         $validDomains = $this->hlp->getValidDomains();
-        if ($validDomains[0] !== '') {
+        if (count($validDomains) > 0) {
             $userData = $this->getUser();
             if (!$this->hlp->checkMail($userData['mail'])) {
                 msg(sprintf($this->hlp->getLang("rejectedEMail"),join(', ', $validDomains)),-1);

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -39,7 +39,7 @@ $meta['doorkeeper-key']      = array('string');
 $meta['doorkeeper-secret']   = array('string');
 $meta['doorkeeper-authurl']  = array('string');
 $meta['doorkeeper-tokenurl'] = array('string');
-$meta['mailRestriction']     = array('string','_pattern' => '!^@.*|^$!');
+$meta['mailRestriction']     = array('string','_pattern' => '!^(@[^,@]+(\.[^,@]+)+(,|$))*$!'); // https://regex101.com/r/mG4aL5/3
 $meta['singleService']       = array('multichoice',
                                      '_choices' => array(
                                          '',

--- a/helper.php
+++ b/helper.php
@@ -130,6 +130,9 @@ class helper_plugin_oauth extends DokuWiki_Plugin {
      * @return array
      */
     public function getValidDomains() {
+        if ($this->getConf('mailRestriction') === '') {
+            return array();
+        }
         $validDomains = explode(',', trim($this->getConf('mailRestriction'), ','));
         $validDomains = array_map('trim', $validDomains);
         return $validDomains;

--- a/helper.php
+++ b/helper.php
@@ -127,23 +127,12 @@ class helper_plugin_oauth extends DokuWiki_Plugin {
     }
 
     /**
-     * @param bool $string if true returns a nice string for output, otherwise returns array of strings
-     *
-     * @return array|string
+     * @return array
      */
-    public function getValidDomains($string = false) {
+    public function getValidDomains() {
         $validDomains = explode(',', trim($this->getConf('mailRestriction'), ','));
-        if ($string) {
-            $domainListing = $validDomains[0];
-            array_shift($validDomains);
-            while (count($validDomains) > 0) {
-                $domainListing .= ", " . $validDomains[0];
-                array_shift($validDomains);
-            }
-            return $domainListing;
-        } else {
-            return $validDomains;
-        }
+        $validDomains = array_map('trim', $validDomains);
+        return $validDomains;
     }
 
     /**

--- a/helper.php
+++ b/helper.php
@@ -125,6 +125,42 @@ class helper_plugin_oauth extends DokuWiki_Plugin {
         $service = strtolower($service);
         return $this->getConf($service.'-tokenurl');
     }
+
+    /**
+     * @param bool $string if true returns a nice string for output, otherwise returns array of strings
+     *
+     * @return array|string
+     */
+    public function getValidDomains($string = false) {
+        $validDomains = explode(',', trim($this->getConf('mailRestriction'), ','));
+        if ($string) {
+            $domainListing = $validDomains[0];
+            array_shift($validDomains);
+            while (count($validDomains) > 0) {
+                $domainListing .= ", " . $validDomains[0];
+                array_shift($validDomains);
+            }
+            return $domainListing;
+        } else {
+            return $validDomains;
+        }
+    }
+
+    /**
+     * @param string $mail
+     *
+     * @return bool
+     */
+    public function checkMail($mail) {
+        $hostedDomains = $this->getValidDomains();
+
+        foreach ($hostedDomains as $validDomain) {
+            if(substr($mail, -strlen($validDomain)) === $validDomain) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
 
 // vim:ts=4:sw=4:et:

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -10,5 +10,5 @@ $lang['loginwith']      = 'Login with other Services:';
 $lang['authnotenabled'] = 'The account associated with your email address has not enabled logging in with %s. Please login by other means and enable it in your profile.';
 $lang['wrongConfig'] = 'The oAuth plugin has been malconfiguered. Defaulting to local authentication only. Please contact your wiki administrator.';
 $lang['loginButton'] = 'Login with ';//... i.e. Google (on SingleAuth)
-$lang['rejectedEMail'] = 'Invalid eMail-Account used. Only accounts from "%s" are allowed!';
-$lang['eMailRestricted'] = '<p id="oauth_email_restricted">Only email accounts from "%s" are allowed.</p>';
+$lang['rejectedEMail'] = 'Invalid eMail-Account used. Only email accounts from the following domain(s) are allowed: %s!';
+$lang['eMailRestricted'] = '<p id="oauth_email_restricted">Only email accounts from the following domain(s) are allowed: %s</p>';


### PR DESCRIPTION
This addresses two issues:

1. it is now possible to define more than one domain, when restricting the valid domains for login
2. if registration is disabled via `$conf['disableactions']`, then it's no longer possible for new users to register + login via oauth.

This also fixes the registration issue in #6 properly.