### PR TITLE
Add google login hint if we have a google session

### DIFF
--- a/classes/GoogleAdapter.php
+++ b/classes/GoogleAdapter.php
@@ -35,4 +35,14 @@ class GoogleAdapter extends AbstractAdapter {
         return array(Google::SCOPE_USERINFO_EMAIL, Google::SCOPE_USERINFO_PROFILE);
     }
 
+    public function login() {
+        $login_hint = '';
+        if(!empty($_SESSION[DOKU_COOKIE]['auth']['info']['mail'])) {
+            $usermail = $_SESSION[DOKU_COOKIE]['auth']['info']['mail'];
+            $login_hint = "&login_hint=$usermail";
+        }
+        $url = $this->oAuth->getAuthorizationUri() . $login_hint;
+        send_redirect($url);
+    }
+
 }


### PR DESCRIPTION
If a session needs to be rechecked, we have the email-address of the corresponding google-account. This can be provided to google as login_hint, which should speed up the relogin process or make user interaction completely unnecessary, if a valid session of this account exists at google. This is already the case if the user has only a single account associated in that browser with google.

See also: https://developers.google.com/identity/protocols/OAuth2UserAgent#formingtheurl