### PR TITLE
Google: Support DokuWiki farms created by the Farmer-Plugin

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -22,6 +22,24 @@ class auth_plugin_oauth extends auth_plugin_authplain {
         $this->cando['external'] = true;
     }
 
+    private function handleState($state) {
+        /** @var \helper_plugin_farmer $farmer */
+        $farmer = plugin_load('helper', 'farmer', false, true);
+        $data = json_decode(base64_decode(urldecode($state)));
+        if (empty($data->animal) || $farmer->getAnimal() == $data->animal) {
+            return;
+        }
+        $animal = $data->animal;
+        $allAnimals = $farmer->getAllAnimals();
+        if (!in_array($animal, $allAnimals)) {
+            msg('Animal ' . $animal . ' does not exist!');
+            return;
+        }
+        global $INPUT;
+        $url = $farmer->getAnimalURL($animal) . 'doku.php?' . $INPUT->server->str('QUERY_STRING');
+        send_redirect($url);
+    }
+
     /**
      * Handle the login
      *
@@ -34,7 +52,11 @@ class auth_plugin_oauth extends auth_plugin_authplain {
      * @return bool
      */
     function trustExternal($user, $pass, $sticky = false) {
-        global $USERINFO;
+        global $USERINFO, $INPUT;
+
+        if ($INPUT->has('state') && plugin_load('helper', 'farmer', false, true)) {
+            $this->handleState($INPUT->str('state'));
+        }
 
         // check session for existing oAuth login data
         $session = $_SESSION[DOKU_COOKIE]['auth'];

--- a/classes/AbstractAdapter.php
+++ b/classes/AbstractAdapter.php
@@ -96,7 +96,7 @@ abstract class AbstractAdapter {
      * @return bool
      */
     public function checkToken() {
-        global $INPUT;
+        global $INPUT, $conf;
 
         if(is_a($this->oAuth, 'OAuth\OAuth2\Service\AbstractService')) { /* oAuth2 handling */
 
@@ -107,6 +107,7 @@ abstract class AbstractAdapter {
                 $this->oAuth->requestAccessToken($INPUT->get->str('code'), $state);
             } catch (TokenResponseException $e) {
                 msg($e->getMessage(), -1);
+                if($conf['allowdebug']) msg('<pre>'.hsc($e->getTraceAsString()).'</pre>', -1);
                 return false;
             }
         } else { /* oAuth1 handling */

--- a/classes/GoogleAdapter.php
+++ b/classes/GoogleAdapter.php
@@ -36,12 +36,19 @@ class GoogleAdapter extends AbstractAdapter {
     }
 
     public function login() {
-        $login_hint = '';
+        $parameters = array();
         if(!empty($_SESSION[DOKU_COOKIE]['auth']['info']['mail'])) {
             $usermail = $_SESSION[DOKU_COOKIE]['auth']['info']['mail'];
-            $login_hint = "&login_hint=$usermail";
+            $parameters['login_hint'] = $usermail;
         }
-        $url = $this->oAuth->getAuthorizationUri() . $login_hint;
+
+        /** @var \helper_plugin_farmer $farmer */
+        $farmer = plugin_load('helper', 'farmer', false, true);
+        if ($farmer && $animal = $farmer->getAnimal()) {
+            $parameters['state'] = urlencode(base64_encode(json_encode(array('animal'=>$animal,'state'=> md5(rand())))));
+            $this->storage->storeAuthorizationState('Google', $parameters['state']);
+        }
+        $url = $this->oAuth->getAuthorizationUri($parameters);
         send_redirect($url);
     }
 

--- a/classes/oAuthHTTPClient.php
+++ b/classes/oAuthHTTPClient.php
@@ -37,7 +37,8 @@ class oAuthHTTPClient implements ClientInterface {
 
         $ok = $http->sendRequest($endpoint->getAbsoluteUri(), $requestBody, $method);
         if(!$ok){
-            throw new TokenResponseException($http->error);
+            $msg = "An error occured during the request to the oauth provider:\n";
+            throw new TokenResponseException($msg . $http->error);
         }
 
         return $http->resp_body;


### PR DESCRIPTION
Animals in a Farm currently need individual configuration in order to work with oauth.

For Google as oauth-provider and for farms created with the [farmer-plugin](https://github.com/cosmocode/dokuwiki-plugin-farmer) this pull-request will utilize the ``state``-variable to achieve local routing so that no additional configuration is necessary.

If merged, this pull request will fix #34 