### PR TITLE
Fix false positives in modifyUser() duplicate mail address check

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -395,7 +395,7 @@ class auth_plugin_oauth extends auth_plugin_authplain {
 
         if(isset($changes['mail'])) {
             $found = $this->getUserByEmail($changes['mail']);
-            if($found != $user) {
+            if($found !== false && $found != $user) {
                 msg($this->getLang('emailduplicate'), -1);
                 return false;
             }


### PR DESCRIPTION
The `getUserByEmail()` procedure may return `false` if no user is found
in the database matching the given mail address.

In such a case, the `$found != $user` condition will always be true, wrongly
rejecting legit mail address change operations.

Extend the condition to explicitely test for a non-`false` found username.

This fixes invalid "This email is already associated with another user."
errors when attempting to change account email addresses on a DokuWiki setup
with installed OAuth plugin.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>