### PR TITLE
Enable login when self-registration is disabled

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -234,7 +234,7 @@ class auth_plugin_oauth extends auth_plugin_authplain {
             $uinfo['user'] = $user;
             $uinfo['name'] = $sinfo['name'];
             $uinfo['grps'] = array_merge((array) $uinfo['grps'], $sinfo['grps']);
-        } elseif(actionOK('register')) {
+        } elseif(actionOK('register') || $this->getConf('register-on-auth')) {
             $ok = $this->addUser($uinfo, $servicename);
             if(!$ok) {
                 msg('something went wrong creating your user account. please try again later.', -1);

--- a/conf/default.php
+++ b/conf/default.php
@@ -30,3 +30,4 @@ $conf['doorkeeper-authurl']  = 'https://doorkeeper-provider.herokuapp.com/oauth/
 $conf['doorkeeper-tokenurl'] = 'https://doorkeeper-provider.herokuapp.com/oauth/token';
 $conf['mailRestriction']     = '';
 $conf['singleService']       = '';
+$conf['register-on-auth']    = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -61,3 +61,4 @@ $meta['singleService']       = array('multichoice',
                                          'Yahoo',
                                          'Doorkeeper',
                                          'Keycloak'));
+$meta['register-on-auth']    = array('onoff','_caution' => 'security');

--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -23,3 +23,4 @@ $lang['keycloak-secret']       = 'Geheimcode deiner Keycloak Applikation';
 $lang['mailRestriction']       = 'Beschränke Anmeldung auf Benutzerprofile dieser Domäne (optional, muss mit <code>@</code> beginnen)';
 $lang['singleService']         = 'Nur einen oAuth Service zulassen (lokale Anmeldung wird deaktiviert!)';
 $lang['singleService_o_']      = 'Alle Services zulassen';
+$lang['register-on-auth']      = 'Registriere authentifizierte Benutzer selbst wenn Selbstregistrierung in der Hauptkonfiguration nicht erlaubt ist.';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -21,3 +21,4 @@ $lang['dataporten-secret']     = 'Client Geheimhcode Ihrer <a href="https://dash
 $lang['mailRestriction']       = 'Beschränke Anmeldung auf Benutzerprofile dieser Domäne (optional, muss mit <code>@</code> beginnen)';
 $lang['singleService']         = 'Nur einen oAuth Service zulassen (lokale Anmeldung wird deaktiviert!)';
 $lang['singleService_o_']      = 'Alle Services zulassen';
+$lang['register-on-auth']      = 'Authentifizierte Benutzer registrieren, auch wenn Selbstregistrierung in der Hauptkonfiguration nicht erlaubt ist.';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -33,3 +33,4 @@ $lang['doorkeeper-authurl']  = '(Example) The authorization endpoint URL of your
 $lang['doorkeeper-tokenurl'] = '(Example) The access token endpoint URL of your Doorkeeper setup.';
 $lang['singleService']            = 'Login with single oAuth service only (disables local logins!)';
 $lang['singleService_o_'] = 'Allow all services';
+$lang['register-on-auth'] = 'Register authenticated users even if self-registration is disabled in main configuration';


### PR DESCRIPTION
Fixes #74 

Adds a configuration option to allow registering authenticated users, even if self-registration is disabled for everyne