### PR TITLE
Update Auth0 scope to use profile and email

### DIFF
--- a/phpoauthlib/src/OAuth/OAuth2/Service/Auth0.php
+++ b/phpoauthlib/src/OAuth/OAuth2/Service/Auth0.php
@@ -14,7 +14,7 @@ use OAuth\Common\Http\Uri\UriInterface;
 class Auth0 extends AbstractService
 {
 
-    const SCOPE_OPENID = 'openid';
+    const SCOPE_OPENID = 'openid profile email';
     protected $domain;
 
     public function __construct(


### PR DESCRIPTION
Auth0 implementation is currently broken, since you can not get email from just the openid scope.