### PR TITLE
Update GitHub authorization to use token in header instead of query

### DIFF
--- a/phpoauthlib/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/phpoauthlib/src/OAuth/OAuth2/Service/AbstractService.php
@@ -167,6 +167,8 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
             $uri->addToQuery('apikey', $token->getAccessToken());
         } elseif (static::AUTHORIZATION_METHOD_HEADER_BEARER === $this->getAuthorizationMethod()) {
             $extraHeaders = array_merge(array('Authorization' => 'Bearer ' . $token->getAccessToken()), $extraHeaders);
+        } elseif (static::AUTHORIZATION_METHOD_HEADER_TOKEN === $this->getAuthorizationMethod()) {
+            $extraHeaders = array_merge(array('Authorization' => 'token ' . $token->getAccessToken()), $extraHeaders);
         }
 
         $extraHeaders = array_merge($this->getExtraApiHeaders(), $extraHeaders);

--- a/phpoauthlib/src/OAuth/OAuth2/Service/GitHub.php
+++ b/phpoauthlib/src/OAuth/OAuth2/Service/GitHub.php
@@ -122,7 +122,7 @@ class GitHub extends AbstractService
      */
     protected function getAuthorizationMethod()
     {
-        return static::AUTHORIZATION_METHOD_QUERY_STRING;
+        return static::AUTHORIZATION_METHOD_HEADER_TOKEN;
     }
 
     /**

--- a/phpoauthlib/src/OAuth/OAuth2/Service/ServiceInterface.php
+++ b/phpoauthlib/src/OAuth/OAuth2/Service/ServiceInterface.php
@@ -23,6 +23,7 @@ interface ServiceInterface extends BaseServiceInterface
     const AUTHORIZATION_METHOD_QUERY_STRING    = 2;
     const AUTHORIZATION_METHOD_QUERY_STRING_V2 = 3;
     const AUTHORIZATION_METHOD_QUERY_STRING_V3 = 4;
+    const AUTHORIZATION_METHOD_HEADER_TOKEN    = 5;
 
     /**
      * Retrieves and stores/returns the OAuth2 access token after a successful authorization.


### PR DESCRIPTION
GitHub has deprecated the use of authorization via the use of a query parameter and instead wants the token passed in the header. The enclosed patch is an attempt to work-around this issue. It has been tested on our dokuwiki site for about 4 weeks now. Authorization seems to be working and we have had no observable problems. Perhaps someone else can give this a try and hopefully merge it or its equivalent into the upstream base. 