### PR TITLE
Add Keycloak scope to support Keycloak 10

### DIFF
--- a/classes/KeycloakAdapter.php
+++ b/classes/KeycloakAdapter.php
@@ -2,6 +2,8 @@
 
 namespace OAuth\Plugin;
 
+use OAuth\OAuth2\Service\Keycloak;
+
 /**
  * Class KeycloakAdapter
  *
@@ -37,6 +39,15 @@ class KeycloakAdapter extends AbstractAdapter {
         $data['grps'] = $result['groups'];
 
         return $data;
+    }
+
+    /**
+     * Access to user and his email addresses
+     *
+     * @return array
+     */
+    public function getScope() {
+        return array(Keycloak::SCOPE_OPENID);
     }
 
     /**

--- a/phpoauthlib/src/OAuth/OAuth2/Service/Keycloak.php
+++ b/phpoauthlib/src/OAuth/OAuth2/Service/Keycloak.php
@@ -13,6 +13,12 @@ use OAuth\Common\Http\Uri\UriInterface;
 
 class Keycloak extends Generic
 {
+    /**
+     * Defined scopes are listed here:
+     * @link https://www.keycloak.org/docs/latest/server_admin/#_client_scopes
+     */
+    const SCOPE_OPENID = 'openid';
+
     protected function getAuthorizationMethod()
     {
         return static::AUTHORIZATION_METHOD_HEADER_BEARER;


### PR DESCRIPTION
Keycloak 10 returns the error "invalid_scope" when a client tries to
get an access token with no scopes. Fix it.

Close #89 
