### PR TITLE
Add role checking to Keycloak

### DIFF
--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -42,6 +42,7 @@ $meta['keycloak-key']        = array('string');
 $meta['keycloak-secret']     = array('string');
 $meta['keycloak-authurl']    = array('string');
 $meta['keycloak-tokenurl']   = array('string');
+$meta['keycloak-required-role'] = array('string');
 $meta['keycloak-userinfourl'] = array('string');
 $meta['yahoo-key']           = array('string');
 $meta['yahoo-secret']        = array('string');

--- a/helper.php
+++ b/helper.php
@@ -127,6 +127,17 @@ class helper_plugin_oauth extends DokuWiki_Plugin {
     }
 
     /**
+     * Return the configured required role, which has to be a member in the 'role' info, if set.
+     *
+     * @param $service
+     * @return string
+     */
+    public function getRequiredRole($service) {
+        $service = strtolower($service);
+        return $this->getConf($service.'-required-role');
+    }
+
+    /**
      * Return the configured User Info Endpoint URL for the given service
      *
      * @param $service

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -23,6 +23,7 @@ $lang['keycloak-key']      = 'The resource id of your Keycloak application.';
 $lang['keycloak-secret']   = 'The Secret of your Keycloak Application.';
 $lang['keycloak-authurl']  = 'The authorization endpoint URL of your Keycloak setup.';
 $lang['keycloak-tokenurl'] = 'The access token endpoint URL of your Keycloak setup.';
+$lang['keycloak-required-role'] = 'The role, that has to be supplied within the \'role\' claim.';
 $lang['keycloak-userinfourl'] = 'The userinfo endpoint URL of your Keycloak setup.';
 $lang['mailRestriction']   = "Limit authentification to users from this domain (optional, must start with an <code>@</code>)";
 $lang['yahoo-key']       = 'The Consumer Key of your registered <a href="https://developer.apps.yahoo.com/dashboard/createKey.html">Yahoo Application</a>';


### PR DESCRIPTION
In my setup I needed to check, if a user has a specific role to be allowed to log in, so I added a config option `keycloak-required-role` which has to be in the `roles`-claim sent in the user token information.