### PR TITLE
Fix #83 - pass OIDC group information into Dokuwiki group list

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -275,7 +275,7 @@ class auth_plugin_oauth extends auth_plugin_authplain {
 
         $ok = $this->triggerUserMod(
             'create',
-            array($user, auth_pwgen($user), $uinfo['name'], $uinfo['mail'], $groups_on_creation,)
+            array($user, auth_pwgen($user), $uinfo['name'], $uinfo['mail'], $uinfo['grps'],)
         );
         if(!$ok) {
             return false;


### PR DESCRIPTION
This is a fix done by @wintamute and discussed on cosmocode#83, but which doesn't seem to have a pull request.

This passes the group list from OpenID Connect / OAuth2 (and especially Keycloak) through to Dokuwiki as a group list.

This can be extremely helpful when paired with Dokuwiki's ACL management, to allow access to pages and namespaces based on OIDC group membership.