### PR TITLE
Enable oauth service plugins to implement their own procedures on logout

### DIFF
--- a/Adapter.php
+++ b/Adapter.php
@@ -268,6 +268,17 @@ abstract class Adapter extends ActionPlugin
     // region overridable methods
 
     /**
+     * Called on logout
+     *
+     * If there are required procedures for the service, you can implement them by overriding this.
+     *
+     * @return void
+     */
+    public function logout()
+    {
+    }
+
+    /**
      * Retrieve the user's data via API
      *
      * The returned array needs to contain at least 'email', 'name', 'user' and optionally 'grps'

--- a/OAuthManager.php
+++ b/OAuthManager.php
@@ -137,6 +137,25 @@ class OAuthManager
         return true;
     }
 
+    /**
+     * Callback service's logout
+     *
+     * @return void
+     */
+    public function logout()
+    {
+        $session = Session::getInstance();
+        $cookie = $session->getCookie();
+        if (!$cookie) return;
+        try {
+            $service = $this->loadService($cookie['servicename']);
+            $service->initOAuthService($cookie['storageId']);
+            $service->logout();
+        } catch (\OAuth\Common\Exception\Exception $e) {
+            return;
+        }
+    }
+
     // endregion
 
     /**

--- a/auth.php
+++ b/auth.php
@@ -16,6 +16,9 @@ class auth_plugin_oauth extends auth_plugin_authplain
     /** @var helper_plugin_oauth */
     protected $hlp;
 
+    /** @var OAuthManager */
+    protected $om;
+
     // region standard auth methods
 
     /** @inheritDoc */
@@ -38,8 +41,8 @@ class auth_plugin_oauth extends auth_plugin_authplain
 
         try {
             // either oauth or "normal" plain auth login via form
-            $om = new OAuthManager();
-            return $om->continueFlow() || auth_login($user, $pass, $sticky);
+            $this->om = new OAuthManager();
+            return $this->om->continueFlow() || auth_login($user, $pass, $sticky);
         } catch (OAuthException $e) {
             $this->hlp->showException($e);
             auth_logoff(); // clears all session and cookie data
@@ -92,6 +95,9 @@ class auth_plugin_oauth extends auth_plugin_authplain
     public function logOff()
     {
         parent::logOff();
+        if (isset($this->om)) {
+            $this->om->logout();
+        }
         (Session::getInstance())->clear();
     }
 


### PR DESCRIPTION
Although some oauth services need their own procedures on logout
(e.g. Keycloak needs to access the logout endpoint), there is no way to
implement them. Fix it.

Close #114 