### PR TITLE
add hideLocal and denyLocal login option

### DIFF
--- a/action/login.php
+++ b/action/login.php
@@ -114,9 +114,10 @@ class action_plugin_oauth_login extends DokuWiki_Action_Plugin
         $html = $this->prepareLoginButtons();
         if (!$html) return;
 
-        // remove login form if single service is set
-        $singleService = $this->getConf('singleService');
-        if ($singleService) {
+        // remove login form if local logins are denied
+        $denyLocal = $this->getConf('denyLocal');
+        $hideLocal = $this->getConf('hideLocal');
+        if ($denyLocal or $hideLocal) {
             do {
                 $form->removeElement(0);
             } while ($form->elementCount() > 0);

--- a/auth.php
+++ b/auth.php
@@ -43,8 +43,8 @@ class auth_plugin_oauth extends auth_plugin_authplain
             // either oauth or "normal" plain auth login via form
             $this->om = new OAuthManager();
             if ($this->om->continueFlow()) return true;
-            if($this->getConf('singleService')) {
-                return false; // no normal login in singleService mode
+            if($this->getConf('denyLocal')) {
+                return false; // deny local logins
             }
             return null; // triggers the normal auth_login()
         } catch (OAuthException $e) {

--- a/conf/default.php
+++ b/conf/default.php
@@ -9,5 +9,7 @@ $conf['info'] = '';
 $conf['custom-redirectURI']  = '';
 $conf['mailRestriction']     = '';
 $conf['singleService']       = '';
+$conf['hideLocal']           = '';
+$conf['denyLocal']           = '';
 $conf['register-on-auth']    = 0;
 $conf['overwrite-groups']    = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -10,5 +10,7 @@ $meta['info']                = array(\dokuwiki\plugin\oauth\RedirectSetting::cla
 $meta['custom-redirectURI']  = array('string','_caution' => 'warning');
 $meta['mailRestriction']     = array('string','_pattern' => '!^(@[^,@]+(\.[^,@]+)+(,|$))*$!'); // https://regex101.com/r/mG4aL5/3
 $meta['singleService']       = array('onoff');
+$meta['hideLocal'] 	         = array('onoff');
+$meta['denyLocal'] 	         = array('onoff','_caution' => 'danger');
 $meta['register-on-auth']    = array('onoff','_caution' => 'security');
 $meta['overwrite-groups']    = array('onoff','_caution' => 'danger');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -9,7 +9,9 @@
 $lang['info']            = 'Redirect URI to use when configuring the applications';
 $lang['custom-redirectURI'] = 'Use the following custom redirect URI';
 $lang['mailRestriction']   = "Limit authentification to users from this domain (optional, must start with an <code>@</code>)";
-$lang['singleService']            = 'Login with single oAuth service only (disables local logins!)';
+$lang['singleService']    = 'Auto redirect to single oAuth service instead of showing login form (does not technically disable local logins. See denyLocal)';
 $lang['singleService_o_'] = 'Allow all services';
+$lang['hideLocal'] 	      = 'Hide local login form and only show available services';
+$lang['denyLocal'] 	      = 'Disable local logins completely';
 $lang['register-on-auth'] = 'Register authenticated users even if self-registration is disabled in main configuration';
 $lang['overwrite-groups'] = 'Overwrite all DokuWiki user groups by those supplied by provider';

--- a/lang/nl/settings.php
+++ b/lang/nl/settings.php
@@ -9,7 +9,9 @@
 $lang['info']                  = 'Redirect URI om te gebruiken voor applicatie configuratie';
 $lang['custom-redirectURI']    = 'Gebruik de volgende custom redirect URI';
 $lang['mailRestriction']       = 'Limiteer authenticatie tot gebruikers van dit domein (optioneel, moet beginnen met <code>@</code>)';
-$lang['singleService']         = 'Login met maar één oAuth-service (schakelt lokale login-methodes uit)';
+$lang['singleService']         = 'Auto redirect naar een enkele oAuth-service (schakelt lokale login-methodes technisch gezien niet uit. Zie denyLocal)';
 $lang['singleService_o_']      = 'Sta alle diensten toe';
+$lang['hideLocal']             = 'Verberg het lokale login-formulier en toon enkel de beschikbare oAuth-services';
+$lang['denyLocal']             = 'Schakel lokale login-methodes volledig uit';
 $lang['register-on-auth']      = 'Geverifieerde gebruikers registreren, zelfs als zelfregistratie is uitgeschakeld in de hoofdconfiguratie';
 $lang['overwrite-groups']      = 'Overschrijf alle DokuWiki gebruikersgroepen met de groepen die geleverd worden door de provider.';


### PR DESCRIPTION
New option hideLocal will hide the local login form, only showing configured services. Local logins are technically still possible (eg. dokuwiki.login API call).
New option denyLocal will do the same but also effectively deny local logins.
singleService will no longer actually deny local logins. Enable denyLocal together with singleService to accomplish this behaviour again.

Can serve as a solution to #134