### PR TITLE
Add HttpTokenResponseException making error handling easy

### DIFF
--- a/HTTPClient.php
+++ b/HTTPClient.php
@@ -4,7 +4,6 @@ namespace dokuwiki\plugin\oauth;
 
 use dokuwiki\HTTP\DokuHTTPClient;
 use OAuth\Common\Http\Client\ClientInterface;
-use OAuth\Common\Http\Exception\TokenResponseException;
 use OAuth\Common\Http\Uri\UriInterface;
 
 /**
@@ -26,7 +25,11 @@ class HTTPClient implements ClientInterface
         $ok = $http->sendRequest($endpoint->getAbsoluteUri(), $requestBody, $method);
         if (!$ok || $http->status < 200 || $http->status > 299) {
             $msg = "An error occured during the request to the oauth provider:\n";
-            throw new TokenResponseException($msg . $http->error . ' [HTTP ' . $http->status . ']');
+            throw new HttpTokenResponseException(
+                $msg . $http->error . ' [HTTP ' . $http->status . ']',
+                $http->status,
+                $http->error
+            );
         }
 
         return $http->resp_body;

--- a/HttpTokenResponseException.php
+++ b/HttpTokenResponseException.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace dokuwiki\plugin\oauth;
+
+use OAuth\Common\Http\Exception\TokenResponseException;
+
+/**
+ * Exception relating to http token response from service.
+ */
+class HttpTokenResponseException extends TokenResponseException
+{
+    protected $httpStatusCode = 0;
+    protected $httpErrorMessage = "";
+
+    /**
+     * @param string $message
+     * @param int $httpStatusCode
+     * @param string httpErrorMessage
+     * @param int $code
+     * @param \Throwable|null $previous
+     */
+    public function __construct(
+        $message = "",
+        $httpStatusCode = 0,
+        $httpErrorMessage = "",
+        $code = 0,
+        \Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->httpStatusCode = $httpStatusCode;
+        $this->httpErrorMessage = $httpErrorMessage;
+    }
+
+    /**
+     * Get the HTTP status code
+     *
+     * @return int
+     */
+    public function getHttpStatusCode()
+    {
+        return $this->httpStatusCode;
+    }
+
+    /**
+     * Get the HTTP error message
+     *
+     * @return string
+     */
+    public function getHttpErrorMessage()
+    {
+        return $this->httpErrorMessage;
+    }
+}


### PR DESCRIPTION
Although http status code and http error message are helpful in error handling, TokenResponseException, throwed by oauth\HTTPClient if an error occured during the http request, does not have fields/methods which indicate them directly.

Solve it by adding HttpTokenResponseException which has indicators of http status code and http error message, and throwing it instead of TokenResponseException.

Close #149 