### PR TITLE
Add http response body to HttpTokenResponseException

### DIFF
--- a/HTTPClient.php
+++ b/HTTPClient.php
@@ -28,7 +28,8 @@ class HTTPClient implements ClientInterface
             throw new HttpTokenResponseException(
                 $msg . $http->error . ' [HTTP ' . $http->status . ']',
                 $http->status,
-                $http->error
+                $http->error,
+                $http->resp_body
             );
         }
 

--- a/HttpTokenResponseException.php
+++ b/HttpTokenResponseException.php
@@ -11,11 +11,13 @@ class HttpTokenResponseException extends TokenResponseException
 {
     protected $httpStatusCode = 0;
     protected $httpErrorMessage = "";
+    protected $httpRespBody = "";
 
     /**
      * @param string $message
      * @param int $httpStatusCode
      * @param string httpErrorMessage
+     * @param mixed httpRespBody
      * @param int $code
      * @param \Throwable|null $previous
      */
@@ -23,12 +25,14 @@ class HttpTokenResponseException extends TokenResponseException
         $message = "",
         $httpStatusCode = 0,
         $httpErrorMessage = "",
+        $httpRespBody = "",
         $code = 0,
         \Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
         $this->httpStatusCode = $httpStatusCode;
         $this->httpErrorMessage = $httpErrorMessage;
+        $this->httpRespBody = $httpRespBody;
     }
 
     /**
@@ -49,5 +53,15 @@ class HttpTokenResponseException extends TokenResponseException
     public function getHttpErrorMessage()
     {
         return $this->httpErrorMessage;
+    }
+
+    /**
+     * Get the HTTP response body
+     *
+     * @return mixed
+     */
+    public function getHttpRespBody()
+    {
+        return $this->httpRespBody;
     }
 }


### PR DESCRIPTION
I found that http response body is also helpful for http clients to handle error.

For instance, Keycloak responds with the body `{ 'error': 'invalid_grant', 'error_description': 'Token is not active' }` to a expired/revolked refresh token. The error handler can parse the body and consider the error as a token expiration.

To enable the error handling with http response body, add it to HttpTokenResponseException.

Thank you.