### PR TITLE
OAuth2: enable state parameter by default

### DIFF
--- a/vendor/lusitanian/oauth/src/OAuth/OAuth2/Service/AbstractService.php
+++ b/vendor/lusitanian/oauth/src/OAuth/OAuth2/Service/AbstractService.php
@@ -42,7 +42,7 @@ abstract class AbstractService extends BaseAbstractService implements ServiceInt
         TokenStorageInterface $storage,
         $scopes = [],
         ?UriInterface $baseApiUri = null,
-        $stateParameterInAutUrl = false,
+        $stateParameterInAutUrl = true,
         $apiVersion = ''
     ) {
         parent::__construct($credentials, $httpClient, $storage);


### PR DESCRIPTION
As a first, simple step to fix #161, I propose to enable the state parameter by default. In contrast to `nonce` and `code_challenge`, it is already implemented in lusitanian/oauth.

`state` is also the oldest and well established mechanism of the three, so I expect that most providers support it. If any provider does not support it, it can be disabled again by overwriting `Service.needsStateParameterInAuthUrl()`.

I understand that this is a breaking change, but I think offering secure defaults is worth it.